### PR TITLE
Fix charter flight listener when PIREP missing

### DIFF
--- a/Listeners/DeleteCharterFlights.php
+++ b/Listeners/DeleteCharterFlights.php
@@ -47,7 +47,7 @@ class DeleteCharterFlights extends Listener
 
             // if Pirep is in progress, then don't do anything.
             $pirep = Pirep::where(['flight_id' => $flight->id, 'user_id' => $flight->user_id])->first();
-            if ($pirep->state == PirepState::IN_PROGRESS) {
+            if ($pirep && $pirep->state == PirepState::IN_PROGRESS) {
                 continue;
             }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="SmartCARS Api Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/DeleteCharterFlightsTest.php
+++ b/tests/DeleteCharterFlightsTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Models\Enums\PirepState;
+
+class DeleteCharterFlightsTest extends TestCase
+{
+    public function testNullPirepCheck()
+    {
+        $pirep = null;
+        $this->assertFalse($pirep && $pirep->state == PirepState::IN_PROGRESS);
+    }
+}


### PR DESCRIPTION
## Summary
- check for null PIREP before examining its state in `DeleteCharterFlights`
- add PHPUnit config and a simple test

## Testing
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f7296804832080c6d501a281762a