### PR TITLE
Fix middleware docblocks and namespaces

### DIFF
--- a/Http/Middleware/SCAuth.php
+++ b/Http/Middleware/SCAuth.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\SmartcARS3phpVMS7Api\Http\Middleware;
+namespace Modules\SmartCARS3phpVMS7Api\Http\Middleware;
 
 use App\Models\User;
 use Closure;
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Log;
 
 /**
  * Class SCAuth
- * @package Modules\SmartCARSvms7\Http\Middleware
+ * @package Modules\SmartCARS3phpVMS7Api\Http\Middleware
  */
 class SCAuth
 {

--- a/Http/Middleware/SCHeaders.php
+++ b/Http/Middleware/SCHeaders.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Modules\SmartcARS3phpVMS7Api\Http\Middleware;
+namespace Modules\SmartCARS3phpVMS7Api\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
 
 /**
- * Class SCAuth
- * @package Modules\SmartCARSvms7\Http\Middleware
+ * Class SCHeaders
+ * @package Modules\SmartCARS3phpVMS7Api\Http\Middleware
  */
 class SCHeaders
 {


### PR DESCRIPTION
## Summary
- correct class name and package in `SCHeaders` middleware
- fix package comment in `SCAuth`
- standardize middleware namespace casing to `SmartCARS3phpVMS7Api`

## Testing
- `php -l Http/Middleware/SCHeaders.php`
- `php -l Http/Middleware/SCAuth.php`


------
https://chatgpt.com/codex/tasks/task_e_6842f707e94083208f568945182da091

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Corrected internal namespaces and capitalization for middleware to ensure consistency across environments; no change to behavior.
  * Standardized package metadata to align with updated module paths.

* Documentation
  * Updated inline annotations to reflect corrected namespaces and class names.

No user-facing changes. Authentication and header handling continue to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->